### PR TITLE
sending content in listener callback android

### DIFF
--- a/android/src/main/java/com/reactlibrary/ClipboardListenerModule.java
+++ b/android/src/main/java/com/reactlibrary/ClipboardListenerModule.java
@@ -51,7 +51,7 @@ public class ClipboardListenerModule extends ReactContextBaseJavaModule {
                     String contents = clipboardMgr.getText().toString();
                     reactContext
                             .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-                            .emit(CLIPBOARD_TEXT_CHANGED, null);
+                            .emit(CLIPBOARD_TEXT_CHANGED, contents);
                 }
             };
         clipboardMgr.addPrimaryClipChangedListener(listener);


### PR DESCRIPTION
With reference to issue: https://github.com/stefanc96/react-native-clipboard-listener/issues/5

Haven't checked if the issue exists on iOS yet. Will update if I find any.